### PR TITLE
Electron 5.x compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,3 +178,7 @@ Another method that is included is `downloadFileOrUrl`, which lets you download 
  */
 function downloadFileOrUrl(pathOrUrl, target)
 ```
+
+## Changes in this fork
+
+- fix Electron 5.x compatibility for `rendererRequireDirect` function

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+## Changes in this fork
+
+- fix Electron 5.x compatibility for `rendererRequireDirect` function
+
+
 # DEPRECATED: electron-remote: an asynchronous 'remote', and more
 
 [![No Maintenance Intended](http://unmaintained.tech/badge.svg)](http://unmaintained.tech/)
@@ -178,7 +183,3 @@ Another method that is included is `downloadFileOrUrl`, which lets you download 
  */
 function downloadFileOrUrl(pathOrUrl, target)
 ```
-
-## Changes in this fork
-
-- fix Electron 5.x compatibility for `rendererRequireDirect` function

--- a/src/renderer-require.js
+++ b/src/renderer-require.js
@@ -40,7 +40,9 @@ const BrowserWindow = process.type === 'renderer' ?
  *                              the window.
  */
 export async function rendererRequireDirect(modulePath, timeout=240*1000) {
-  let bw = new BrowserWindow({width: 500, height: 500, show: false});
+  let bw = new BrowserWindow({width: 500, height: 500, show: false, webPreferences: {
+      nodeIntegration: true
+  }});
   let fullPath = require.resolve(modulePath);
 
   let ready = Observable.merge(


### PR DESCRIPTION
Starting Electron 5.x it is necessary to set `nodeIntegration: true` for BrowserWindow instance to use `require` in page context.